### PR TITLE
Quickfix for PHP 7+ compatibility

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -54,7 +54,7 @@ trait Base
     {
         while (strlen($data)) {
             $temp = substr($data, 0, static::$fragmentSize);
-            $data = substr($data, static::$fragmentSize);
+            $data = strlen($data) < static::$fragmentSize ? '' : substr($data, static::$fragmentSize);
             $temp = $this->encode($temp, $opcode, $masked, strlen($data) === 0);
             
             if (!is_resource($socket) || get_resource_type($socket) !== "stream") {


### PR DESCRIPTION
strlen() no longer returns an empty string if $data is smaller than static::$fragmentSize.
This quickfix works on my end and even though this project was inactive for a long time I thought I'd share.

Hope it helps!

If more PHP 7 related pull requests are wished, I'll provide strict types and maybe even a User object to ease sending messages back and provide additional client-server-related functionality.