### PR TITLE
fix for empty cookies and php strict mode

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -230,8 +230,10 @@ class Server
         if (isset($headers['cookie'])) {
             $temp = explode(';', $headers['cookie']);
             foreach ($temp as $v) {
-                $v = explode('=', $v, 2);
-                $cookies[trim($v[0])] = $v[1];
+                if(trim($v) !== '' && strpos($v, '=') !== false){
+                    $v = explode('=', $v, 2);
+                    $cookies[trim($v[0])] = $v[1];
+                }
             }
         }
         $client = [


### PR DESCRIPTION
When some cookies are empty and php has enable strict mode (stops even on warnings) then websocket stops working 